### PR TITLE
Uses PCF ROCK instead of the upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ juju integrate sdcore-pcf:fiveg_nrf sdcore-nrf
 
 ## Image
 
-**pcf**: `omecproject/5gc-pcf:master-bcbdeb0`
+**pcf**: `ghcr.io/canonical/sdcore-pcf:1.3`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
   pcf-image:
     type: oci-image
     description: OCI image for 5G pcf
-    upstream-source: omecproject/5gc-pcf:master-bcbdeb0
+    upstream-source: ghcr.io/canonical/sdcore-pcf:1.3
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,7 +253,7 @@ class PCFOperatorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"./pcf --pcfcfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
+                        "command": f"/bin/pcf --pcfcfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
                         "environment": self._environment_variables,
                     },
                 },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -287,7 +287,7 @@ class TestCharm(unittest.TestCase):
                 "pcf": {
                     "override": "replace",
                     "startup": "enabled",
-                    "command": "./pcf --pcfcfg /etc/pcf/pcfcfg.yaml",
+                    "command": "/bin/pcf --pcfcfg /etc/pcf/pcfcfg.yaml",
                     "environment": {
                         "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
                         "GRPC_GO_LOG_SEVERITY_LEVEL": "info",


### PR DESCRIPTION
# Description

Don't merge before merging the [ROCK](https://github.com/canonical/sdcore-pcf-rock/pull/1).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library