### PR TITLE
Enforce TLS Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,11 @@ A Charmed Operator for SD-Core's Policy Control Function (PCF) component.
 juju deploy mongodb-k8s --channel 5/edge --trust
 juju deploy sdcore-nrf --channel edge --trust
 juju deploy sdcore-pcf --channel edge --trust 
+juju deploy self-signed-certificates --channel=beta
 
 juju integrate sdcore-pcf mongodb-k8s
+juju integrate sdcore-nrf self-signed-certificates
 juju integrate sdcore-pcf:fiveg_nrf sdcore-nrf
-```
-
-### Optional
-
-```bash
-juju deploy self-signed-certificates --channel=edge
 juju integrate sdcore-pcf:certificates self-signed-certificates:certificates
 ```
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -16,6 +16,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APPLICATION_NAME = METADATA["name"]
 NRF_APP_NAME = "sdcore-nrf"
 DATABASE_APP_NAME = "mongodb-k8s"
+TLS_PROVIDER_NAME = "self-signed-certificates"
 
 
 async def _deploy_database(ops_test: OpsTest):
@@ -38,6 +39,14 @@ async def _deploy_nrf(ops_test: OpsTest):
     )
 
 
+async def _deploy_tls_provider(ops_test: OpsTest):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
+        TLS_PROVIDER_NAME,
+        application_name=TLS_PROVIDER_NAME,
+        channel="beta",
+    )
+
+
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
 async def build_and_deploy(ops_test: OpsTest):
@@ -54,6 +63,7 @@ async def build_and_deploy(ops_test: OpsTest):
     )
     await _deploy_database(ops_test)
     await _deploy_nrf(ops_test)
+    await _deploy_tls_provider(ops_test)
 
 
 @pytest.mark.abort_on_fail
@@ -70,10 +80,12 @@ async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
 @pytest.mark.abort_on_fail
 async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
     await ops_test.model.add_relation(relation1=NRF_APP_NAME, relation2=DATABASE_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.add_relation(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.add_relation(relation1=APPLICATION_NAME, relation2=DATABASE_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{APPLICATION_NAME}:fiveg_nrf", relation2=NRF_APP_NAME
     )
+    await ops_test.model.add_relation(relation1=APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)  # type: ignore[union-attr]  # noqa: E501
 
     await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
         apps=[APPLICATION_NAME],
@@ -99,5 +111,26 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
     await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{NRF_APP_NAME}:database", relation2=DATABASE_APP_NAME
     )
+    await ops_test.model.add_relation(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.add_relation(relation1=APPLICATION_NAME, relation2=NRF_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_tls_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.remove_application(TLS_PROVIDER_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
+        TLS_PROVIDER_NAME,
+        application_name=TLS_PROVIDER_NAME,
+        channel="beta",
+        trust=True,
+    )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=APPLICATION_NAME, relation2=TLS_PROVIDER_NAME
+    )
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/unit/expected_pcfcfg.yaml
+++ b/tests/unit/expected_pcfcfg.yaml
@@ -9,7 +9,7 @@ configuration:
     bindingIPv4: 0.0.0.0
     port: 29507
     registerIPv4: 1.1.1.1
-    scheme: http
+    scheme: https
   serviceList:
   - serviceName: npcf-am-policy-control
   - serviceName: npcf-smpolicycontrol

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,6 +15,7 @@ from charm import (
     CONFIG_FILE_NAME,
     DATABASE_RELATION_NAME,
     NRF_RELATION_NAME,
+    TLS_RELATION_NAME,
     PCFOperatorCharm,
 )
 
@@ -145,6 +146,20 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for `fiveg_nrf` relation to be created"),
         )
 
+    def test_given_container_can_connect_and_certificates_relation_is_not_created_when_configure_sdcore_pcf_then_status_is_blocked(  # noqa: E501
+        self,
+    ):
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        self._create_database_relation()
+        self._create_nrf_relation()
+
+        self.harness.charm._configure_sdcore_pcf(event=Mock())
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Waiting for `certificates` relation to be created"),
+        )
+
     @patch("charm.check_output")
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
@@ -172,13 +187,17 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
+    @patch("ops.model.Container.push")
     def test_given_container_can_connect_and_database_relation_is_not_available_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
         self,
+        patch_push,
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._create_database_relation()
         self._create_nrf_relation()
-
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
         self.harness.charm._configure_sdcore_pcf(event=Mock())
 
         self.assertEqual(
@@ -186,12 +205,17 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for `database` relation to be available"),
         )
 
+    @patch("ops.model.Container.push")
     def test_given_container_can_connect_and_fiveg_nrf_relation_is_not_available_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
         self,
+        patch_push,
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
 
@@ -200,20 +224,52 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for NRF endpoint to be available"),
         )
 
+    @patch("ops.model.Container.push")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_container_storage_is_not_attached_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
-        self, patched_nrf_url
+        self,
+        patched_nrf_url,
+        patch_push,
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
         patched_nrf_url.return_value = VALID_NRF_URL
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
         self.harness.charm._storage_is_attached = Mock(return_value=False)
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
 
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for the storage to be attached")
+        )
+
+    @patch("charm.check_output")
+    @patch("ops.model.Container.push")
+    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    def test_given_certificate_is_not_stored_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
+        self,
+        patched_nrf_url,
+        patch_push,
+        patch_check_output,
+    ):
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        patched_nrf_url.return_value = VALID_NRF_URL
+        self._database_is_available()
+        self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._storage_is_attached = Mock(return_value=True)
+        self.harness.charm._certificate_is_stored = Mock(return_value=False)
+        patch_check_output.return_value = b"1.1.1.1"
+
+        self.harness.charm._configure_sdcore_pcf(event=Mock())
+
+        self.assertEqual(
+            self.harness.model.unit.status, WaitingStatus("Waiting for certificates to be stored")
         )
 
     @patch("charm.check_output")
@@ -230,6 +286,10 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = VALID_NRF_URL
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
         patch_exists.side_effect = [True, False, False]
         expected_config_file_content = self._read_file(EXPECTED_CONFIG_FILE_PATH)
 
@@ -258,6 +318,10 @@ class TestCharm(unittest.TestCase):
         patch_exists.return_value = False
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
 
         self.harness.container_pebble_ready("pcf")
 
@@ -283,6 +347,10 @@ class TestCharm(unittest.TestCase):
         patch_nrf_url.return_value = VALID_NRF_URL
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
         self.harness.set_can_connect(container="pcf", val=True)
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
@@ -306,6 +374,10 @@ class TestCharm(unittest.TestCase):
         patch_exists.side_effect = [True, True, False]
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
@@ -346,6 +418,10 @@ class TestCharm(unittest.TestCase):
         patched_nrf_url.return_value = VALID_NRF_URL
         self._create_nrf_relation()
         self._database_is_available()
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
         self.harness.charm._storage_is_attached = Mock(return_value=True)
         patch_exists.return_value = [True, False]
 
@@ -367,7 +443,9 @@ class TestCharm(unittest.TestCase):
         self._database_is_available()
         self.harness.charm._storage_is_attached = Mock(return_value=True)
         patch_exists.return_value = [True, False]
-
+        self.harness.add_relation(
+            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
+        )
         self.harness.container_pebble_ready(container_name="pcf")
 
         self.assertEqual(


### PR DESCRIPTION
# Description

Enforces TLS integration in the charm. Charm remains in blocked state until the `certificates` relation is created, and in waiting status until a certificate is stored.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library