### PR TITLE
fix: Checks if certificate is already requested

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -170,7 +170,9 @@ class PCFOperatorCharm(CharmBase):
         if not self._private_key_is_stored():
             event.defer()
             return
-        self._request_new_certificate()
+        if not self._certificate_is_stored():
+            self._request_new_certificate()
+            return
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Pushes certificate to workload and configures workload.

--- a/src/charm.py
+++ b/src/charm.py
@@ -170,9 +170,10 @@ class PCFOperatorCharm(CharmBase):
         if not self._private_key_is_stored():
             event.defer()
             return
-        if not self._certificate_is_stored():
-            self._request_new_certificate()
+        if self._certificate_is_stored():
             return
+
+        self._request_new_certificate()
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Pushes certificate to workload and configures workload.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -494,7 +494,7 @@ class TestCharm(unittest.TestCase):
         csr = b"whatever csr content"
         patch_generate_csr.return_value = csr
         patch_pull.return_value = StringIO("private key content")
-        patch_exists.return_value = True
+        patch_exists.side_effect = [True, False]
         self.harness.set_can_connect(container="pcf", val=True)
 
         self.harness.charm._on_certificates_relation_joined(event=Mock)
@@ -508,7 +508,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.generate_csr")
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")
-    def test_given_private_key_exists_when_on_certificates_relation_joined_then_cert_is_requested(
+    def test_given_private_key_exists_and_cert_not_yet_requested_when_on_certificates_relation_joined_then_cert_is_requested(  # noqa: E501
         self,
         patch_exists,
         patch_pull,
@@ -518,12 +518,32 @@ class TestCharm(unittest.TestCase):
         csr = b"whatever csr content"
         patch_generate_csr.return_value = csr
         patch_pull.return_value = StringIO("private key content")
-        patch_exists.return_value = True
+        patch_exists.side_effect = [True, False]
         self.harness.set_can_connect(container="pcf", val=True)
 
         self.harness.charm._on_certificates_relation_joined(event=Mock)
 
         patch_request_certificate_creation.assert_called_with(certificate_signing_request=csr)
+
+    @patch(
+        "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2.request_certificate_creation",  # noqa: E501
+    )
+    @patch("ops.model.Container.push", new=Mock)
+    @patch("ops.model.Container.pull")
+    @patch("ops.model.Container.exists")
+    def test_given_cert_already_stored_when_on_certificates_relation_joined_then_cert_is_not_requested(  # noqa: E501
+        self,
+        patch_exists,
+        patch_pull,
+        patch_request_certificate_creation,
+    ):
+        patch_pull.return_value = StringIO("private key content")
+        patch_exists.return_value = True
+        self.harness.set_can_connect(container="pcf", val=True)
+
+        self.harness.charm._on_certificates_relation_joined(event=Mock)
+
+        patch_request_certificate_creation.assert_not_called
 
     @patch("ops.model.Container.pull")
     @patch("ops.model.Container.exists")


### PR DESCRIPTION
Adds unit tests cases

# Description

Adds a guard in the certificates relation joined handler to check if the cert was already stored before requesting a new one.


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library