### PR TITLE
fix: go into blocked status when database relation is removed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -65,6 +65,7 @@ class PCFOperatorCharm(CharmBase):
         )
         self._certificates = TLSCertificatesRequiresV2(self, "certificates")
         self.framework.observe(self.on.database_relation_joined, self._configure_sdcore_pcf)
+        self.framework.observe(self.on.database_relation_broken, self._on_database_relation_broken)
         self.framework.observe(self._database.on.database_created, self._configure_sdcore_pcf)
         self.framework.observe(self.on.fiveg_nrf_relation_joined, self._configure_sdcore_pcf)
         self.framework.observe(self._nrf_requires.on.nrf_available, self._configure_sdcore_pcf)
@@ -132,6 +133,14 @@ class PCFOperatorCharm(CharmBase):
             event (NRFBrokenEvent): Juju event
         """
         self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
+
+    def _on_database_relation_broken(self, event: EventBase) -> None:
+        """Event handler for database relation broken.
+
+        Args:
+            event: Juju event
+        """
+        self.unit.status = BlockedStatus("Waiting for database relation")
 
     def _on_certificates_relation_created(self, event: EventBase) -> None:
         """Generates Private key.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -136,3 +136,29 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_a
     )
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=TLS_PROVIDER_NAME)
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+
+
+@pytest.mark.skip(
+    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
+)
+@pytest.mark.abort_on_fail
+async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(DATABASE_APP_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)
+
+
+@pytest.mark.skip(
+    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
+)
+@pytest.mark.abort_on_fail
+async def test_restore_database_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await ops_test.model.deploy(
+        DATABASE_APP_NAME,
+        application_name=DATABASE_APP_NAME,
+        channel="5/edge",
+        trust=True,
+    )
+    await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)


### PR DESCRIPTION
# Description

This PR aims to fix #30 . When database relation is removed, move into Blocked status.
As agreed, new integration tests are not executed until canonical/mongodb-k8s-operator#218 will be fixed.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library