### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
     with:
-      charm-file-name: "sdcore-pcf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-pcf-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,5 +39,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-pcf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-pcf-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# SD-Core PCF Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-pcf/badge.svg)](https://charmhub.io/sdcore-pcf)
+# SD-Core PCF K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-pcf-k8s/badge.svg)](https://charmhub.io/sdcore-pcf-k8s)
 
-A Charmed Operator for SD-Core's Policy Control Function (PCF) component. 
+A Charmed K8s Operator for SD-Core's Policy Control Function (PCF) component. 
 
 ## Usage
 
 ```bash
 juju deploy mongodb-k8s --channel 5/edge --trust
-juju deploy sdcore-nrf --channel edge
-juju deploy sdcore-pcf --channel edge 
+juju deploy sdcore-nrf-k8s --channel edge
+juju deploy sdcore-pcf-k8s --channel edge 
 juju deploy self-signed-certificates --channel=beta
 
-juju integrate sdcore-pcf mongodb-k8s
-juju integrate sdcore-nrf self-signed-certificates
-juju integrate sdcore-pcf:fiveg_nrf sdcore-nrf
-juju integrate sdcore-pcf:certificates self-signed-certificates:certificates
+juju integrate sdcore-pcf-k8s mongodb-k8s
+juju integrate sdcore-nrf-k8s self-signed-certificates
+juju integrate sdcore-pcf-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
+juju integrate sdcore-pcf-k8s:certificates self-signed-certificates:certificates
 ```
 
 ## Image

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,12 +1,12 @@
-name: sdcore-pcf
+name: sdcore-pcf-k8s
 
-display-name: SD-Core PCF
+display-name: SD-Core PCF K8s
 summary: A Charmed Operator for SD-Core's PCF component.
 description: |
   A Charmed Operator for SD-Core's Policy Control Function (PCF) component.
-website: https://charmhub.io/sdcore-pcf
-source: https://github.com/canonical/sdcore-pcf-operator
-issues: https://github.com/canonical/sdcore-pcf-operator/issues
+website: https://charmhub.io/sdcore-pcf-k8s
+source: https://github.com/canonical/sdcore-pcf-k8s-operator
+issues: https://github.com/canonical/sdcore-pcf-k8s-operator/issues
 
 containers:
   pcf:

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core's PCF service."""
+"""Charmed K8s operator for the SD-Core's PCF service."""
 
 import logging
 from ipaddress import IPv4Address
@@ -41,8 +41,8 @@ CERTIFICATE_NAME = "pcf.pem"
 CERTIFICATE_COMMON_NAME = "pcf.sdcore"
 
 
-class PCFOperatorCharm(CharmBase):
-    """Main class to describe Juju event handling for the 5G PCF operator."""
+class PCFK8sOperatorCharm(CharmBase):
+    """Main class to describe Juju event handling for the 5G PCF K8s operator."""
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -489,4 +489,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(PCFOperatorCharm)
+    main(PCFK8sOperatorCharm)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APPLICATION_NAME = METADATA["name"]
-NRF_APP_NAME = "sdcore-nrf"
+NRF_APP_NAME = "sdcore-nrf-k8s"
 DATABASE_APP_NAME = "mongodb-k8s"
 TLS_PROVIDER_NAME = "self-signed-certificates"
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,7 +14,7 @@ from charm import (
     DATABASE_RELATION_NAME,
     NRF_RELATION_NAME,
     TLS_RELATION_NAME,
-    PCFOperatorCharm,
+    PCFK8sOperatorCharm,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,7 +30,7 @@ class TestCharm(unittest.TestCase):
         self.default_database_application_name = "mongodb-k8s"
         self.metadata = self._get_metadata()
         self.container_name = list(self.metadata["containers"].keys())[0]
-        self.harness = testing.Harness(PCFOperatorCharm)
+        self.harness = testing.Harness(PCFK8sOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) . Please wait for the SD-Core charm names to be updated in Charmhub before merging.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library